### PR TITLE
Render as something else than input

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ _Note: react/react-dom is a peer dependency. You should be using this in a React
   style={{ display: 'none' }}
   minLength={5}
   minScore={2}
+  as={input}
   scoreWords={['weak', 'okay', 'good', 'strong', 'stronger']}
   changeCallback={foo}
   inputProps={{ name: "password_input", autoComplete: "off", className: "form-control" }}
@@ -71,6 +72,10 @@ Using in a Universal JS App (server-side rendering):
 #### tooShortWord (Default: 'too short')
 
 - A string to describe when password is too short (based on minLength prop).
+
+#### as (Default: input)
+
+- The base element included inside the ReactPasswordStrengh container.
 
 #### changeCallback
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,6 @@ export default class ReactPasswordStrength extends React.Component {
       isValid: false,
       password: '',
     }, () => {
-      this.refs['ReactPasswordStrength-input'].value = '';
-
       if (changeCallback !== null) {
         changeCallback(this.state);
       }
@@ -35,7 +33,7 @@ export default class ReactPasswordStrength extends React.Component {
 
   handleChange(e) {
     const { changeCallback, minScore } = this.props;
-    const password = this.refs['ReactPasswordStrength-input'].value;
+    const password = e.target.value;
 
     let score;
 
@@ -71,6 +69,8 @@ export default class ReactPasswordStrength extends React.Component {
       tooShortWord
     } = this.props;
 
+    const ElementType = this.props.as ? this.props.as : 'input'
+
     const wrapperClasses = [
       'ReactPasswordStrength',
       className ? className : '',
@@ -99,15 +99,13 @@ export default class ReactPasswordStrength extends React.Component {
 
     return (
       <div className={wrapperClasses.join(' ')} style={style}>
-        <input
+        <ElementType
           type="password"
           {...inputProps}
           className={inputClasses.join(' ')}
           onChange={this.handleChange.bind(this)}
-          ref="ReactPasswordStrength-input"
           value={password}
         />
-
         <div className="ReactPasswordStrength-strength-bar" />
         <span className="ReactPasswordStrength-strength-desc">{strengthDesc}</span>
       </div>

--- a/test/index.js
+++ b/test/index.js
@@ -23,6 +23,20 @@ describe('ReactPasswordStrength', () => {
     expect(children[2].props.className).toBe('ReactPasswordStrength-strength-desc');
   });
 
+  it('use as prop for subelem', () => {
+    const Input = () => (
+      <input className="testAs"/>
+    )
+    renderer.render(<PassStrength as={Input}/>);
+    const result = renderer.getRenderOutput();
+    const { children } = result.props;
+    expect(result.type).toBe('div');
+
+    expect(typeof(children[0].type)).toBe('function');
+    expect(children[0].type().type).toBe('input');
+    expect(children[0].type().props.className).toBe('testAs');
+  });
+
   it('passes inputProps to input elem', () => {
     const inputProps = {
       className: 'test',


### PR DESCRIPTION
Add the capability to render as something than an input. For example a `Input` or a `Field.Input` from https://react.semantic-ui.com/elements/input