### PR TITLE
Added support for defaultValue prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Using in a Universal JS App (server-side rendering):
   - Passing in `className` will amend to the existing classes
   - The remaining props will be ignored
 
+#### defaultValue
+
+- A default value to set for the password field. If a non-empty string is provided the `changeCallback` will be called in `componentDidMount`.
+
 #### userInputs
 
 - An array of strings that zxcvbn will treat as an extra dictionary.

--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,22 @@ import zxcvbn from 'zxcvbn';
 import PropTypes from 'prop-types';
 
 export default class ReactPasswordStrength extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       score: 0,
       isValid: false,
-      password: '',
+      password: props.defaultValue,
     };
+  }
+
+  componentDidMount() {
+    const {password} = this.state;
+
+    if (password) { // If a defaultValue was set, call handleChange after mounting
+      this.handleChange();
+    }
   }
 
   clear() {
@@ -125,6 +133,7 @@ ReactPasswordStrength.propTypes = {
   tooShortWord: PropTypes.string,
   style: PropTypes.object,
   userInputs: PropTypes.array,
+  defaultValue: PropTypes.string,
 };
 
 ReactPasswordStrength.defaultProps = {
@@ -135,4 +144,5 @@ ReactPasswordStrength.defaultProps = {
   scoreWords: ['weak', 'weak', 'okay', 'good', 'strong'],
   tooShortWord: 'too short',
   userInputs: [],
+  defaultValue: '',
 };


### PR DESCRIPTION
Added support for `defaultValue` prop that allows an initial value to be set. This is useful for multistep forms as described in issue #55.